### PR TITLE
add experimental @live tag for tonicdev live examples

### DIFF
--- a/lib/structure.js
+++ b/lib/structure.js
@@ -27,6 +27,12 @@ var rawRootFromGitHubUrl = function (branch) {
   return '/raw/' + branch + '/'
 }
 
+module.exports.hasLiveExamples = function (doclet) {
+  if (doclet.tags) {
+    return _.findWhere(doclet.tags, {title: 'live'}) !== undefined
+  }
+}
+
 module.exports.addUrlToDoclets = function (doclets, githubUrl, branch) {
   var fileBaseUrl = githubUrl + fileRootFromGitHubUrl(branch)
   _.each(doclets, function (doclet) {

--- a/lib/view-params.js
+++ b/lib/view-params.js
@@ -113,6 +113,7 @@ module.exports.getApiParams = function (doclet) {
   return {
     doclet: doclet,
     childs: structure.childs,
+    hasLiveExamples: structure.hasLiveExamples,
     '_': _,
     tools: tools,
     versionsPath: './',

--- a/views/details.jade
+++ b/views/details.jade
@@ -1,7 +1,14 @@
-mixin examples(examplesArray)
+- var exampleIndex = 0
+mixin examples(examplesArray, live)
 	each example in examplesArray
-		pre.example
-			code= example
+		if live
+			- exampleIndex++
+			- id = 'example-' + exampleIndex
+			script(src='https://embed.tonicdev.com' data-element-id=id, defer=true)
+			div.live(id=id)= example
+		else
+			pre.example
+				code= example
 
 
 mixin see(seeArray)
@@ -106,7 +113,7 @@ mixin details(doclet)
 		//p= JSON.stringify(doclet.properties)
 	if doclet.examples
 		h4 Example code:
-		+examples(doclet.examples)
+		+examples(doclet.examples, hasLiveExamples(doclet))
 	if doclet.see
 		+see(doclet.see)
 	


### PR DESCRIPTION
Adds support for the custom “@live” tag. All entities using “@live” will have their examples embedded in tonicdev.