### PR TITLE
Filepaths containing spaces don't work

### DIFF
--- a/lib/gather.js
+++ b/lib/gather.js
@@ -35,6 +35,8 @@ var createDoclets = function (config, workDir) {
     } else {
       return process.cwd() + '/' + fileName
     }
+  }).map(function (fileName) {
+    return '"' + fileName + '"'
   })
   jsdocOptions.push('-t')
   jsdocOptions.push(__dirname + '/capture-template')


### PR DESCRIPTION
See [issue 124](https://github.com/lipp/doclets/issues/124)
Added quotes around all file names to ensure they are passed properly.