### PR TITLE
Fix issues with tests on Travis CI

### DIFF
--- a/test/doc-worker_spec.js
+++ b/test/doc-worker_spec.js
@@ -22,7 +22,7 @@ var loadGitHubEvent = function (eventDir) {
 var tmpPath = path.join(__dirname, 'git-temp')
 
 describe('The doc-worker module', function () {
-  this.timeout(150000)
+  this.timeout(300000)
   this.slow(8000)
   var inbox
   var failed

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -23,7 +23,7 @@ var clearDb = function (done) {
 }
 
 describe('The server module', function () {
-  this.timeout(8000)
+  this.timeout(16000)
 
   after(function (done) {
     mongoose.connection.close(done)

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -79,7 +79,7 @@ describe('The server module', function () {
       server.init.bind(null, 4444),
       clearDb,
       doclet.save.bind(doclet),
-      doclet2.save.bind(doclet),
+      doclet2.save.bind(doclet2),
       user.save.bind(user),
       repo.save.bind(repo)
     ], done)

--- a/test/tree_spec.js
+++ b/test/tree_spec.js
@@ -14,6 +14,8 @@ var loadFixture = function (name) {
 }
 
 describe('tree', function () {
+  this.timeout(10000)
+
   describe('amd', function () {
     var modules
 


### PR DESCRIPTION
There seem to be two main issues causing tests to fail on Travis CI:

1. A typo in the server_spec.js file caused an incorrect model to be bound to the Doclet.save function, resulting in a test failure once the mongoose dependency was upgraded to 4.8.x
2. Tests are frequently timing out.

I've fixed the typo for 1), and doubled the test timeout for problematic tests in 2).